### PR TITLE
Fix app_logging when used on OS X. Changed platformm check from'Darwi…

### DIFF
--- a/Boot1/app_logging.py
+++ b/Boot1/app_logging.py
@@ -46,7 +46,7 @@ class AppLogger(object):
             AppLogger.logger = logging.getLogger(AppLogger.__app_name)
             AppLogger.logger.setLevel(level=logging.DEBUG)
             log_address = '/dev/log'
-            if sys.platform == 'Darwin':
+            if sys.platform == 'darwin':
                 log_address = '/var/run/syslog'
 
             if sys.platform == 'win32':

--- a/app_template/app_logging.py
+++ b/app_template/app_logging.py
@@ -46,7 +46,7 @@ class AppLogger(object):
             AppLogger.logger = logging.getLogger(AppLogger.__app_name)
             AppLogger.logger.setLevel(level=logging.DEBUG)
             log_address = '/dev/log'
-            if sys.platform == 'Darwin':
+            if sys.platform == 'darwin':
                 log_address = '/var/run/syslog'
 
             if sys.platform == 'win32':

--- a/ibr1700_gnss/app_logging.py
+++ b/ibr1700_gnss/app_logging.py
@@ -46,7 +46,7 @@ class AppLogger(object):
             AppLogger.logger = logging.getLogger(AppLogger.__app_name)
             AppLogger.logger.setLevel(level=logging.DEBUG)
             log_address = '/dev/log'
-            if sys.platform == 'Darwin':
+            if sys.platform == 'darwin':
                 log_address = '/var/run/syslog'
 
             if sys.platform == 'win32':

--- a/ibr1700_obdII/app_logging.py
+++ b/ibr1700_obdII/app_logging.py
@@ -46,7 +46,7 @@ class AppLogger(object):
             AppLogger.logger = logging.getLogger(AppLogger.__app_name)
             AppLogger.logger.setLevel(level=logging.DEBUG)
             log_address = '/dev/log'
-            if sys.platform == 'Darwin':
+            if sys.platform == 'darwin':
                 log_address = '/var/run/syslog'
 
             if sys.platform == 'win32':

--- a/mqtt_app/app_logging.py
+++ b/mqtt_app/app_logging.py
@@ -46,7 +46,7 @@ class AppLogger(object):
             AppLogger.logger = logging.getLogger(AppLogger.__app_name)
             AppLogger.logger.setLevel(level=logging.DEBUG)
             log_address = '/dev/log'
-            if sys.platform == 'Darwin':
+            if sys.platform == 'darwin':
                 log_address = '/var/run/syslog'
 
             if sys.platform == 'win32':

--- a/python_module_list/app_logging.py
+++ b/python_module_list/app_logging.py
@@ -46,7 +46,7 @@ class AppLogger(object):
             AppLogger.logger = logging.getLogger(AppLogger.__app_name)
             AppLogger.logger.setLevel(level=logging.DEBUG)
             log_address = '/dev/log'
-            if sys.platform == 'Darwin':
+            if sys.platform == 'darwin':
                 log_address = '/var/run/syslog'
 
             if sys.platform == 'win32':

--- a/simple_custom_dashboard/app_logging.py
+++ b/simple_custom_dashboard/app_logging.py
@@ -46,7 +46,7 @@ class AppLogger(object):
             AppLogger.logger = logging.getLogger(AppLogger.__app_name)
             AppLogger.logger.setLevel(level=logging.DEBUG)
             log_address = '/dev/log'
-            if sys.platform == 'Darwin':
+            if sys.platform == 'darwin':
                 log_address = '/var/run/syslog'
 
             if sys.platform == 'win32':


### PR DESCRIPTION
The app_logging.py is broken for OS X. Changed a platform check from 'Darwin' to 'darwin'. Otherwise an exception will occur. 