### PR TITLE
Fix versioning issue with Boot1

### DIFF
--- a/Boot1/Boot1.py
+++ b/Boot1/Boot1.py
@@ -410,7 +410,7 @@ class SIMSpeedTest(object):
         fw_patch = int(self.client.get("/status/fw_info/patch_version").get('data', ''))
         log.info("Current FW Version - major: %s, minor: %s, patch: %s",
                  fw_major, fw_minor, fw_patch)
-        return fw_major >= major and fw_minor >= minor and fw_patch >= patch
+        return (fw_major, fw_minor, fw_patch) >= (major, minor, patch)
 
     def wait_to_start(self):
         while not self.NTP_time_updated():


### PR DESCRIPTION
Boot1's original version test would fail when upgrading Cradlepoint
firmware from 6.x.y -> 7.0.y (where x > 0).  Using a tuple equality test
solves the issue.