### PR TITLE
don't mess with my ssh settings

### DIFF
--- a/make.py
+++ b/make.py
@@ -221,7 +221,7 @@ def install():
         app_archive = get_app_pack()
 
         # Use sshpass for Linux or OS X
-        cmd = 'sshpass -p {0} scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no {1} {2}@{3}:/app_upload'.format(
+        cmd = 'sshpass -p {0} scp {1} {2}@{3}:/app_upload'.format(
                g_dev_client_password, app_archive,
                g_dev_client_username, g_dev_client_ip)
 


### PR DESCRIPTION
You shouldn't be messing with the users ssh options.  If a developer needs use multiple devices with the same IP they can turn these things off by adding them to their ssh config file.