### PR TITLE
refactor of build process

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,0 +1,91 @@
+import os
+import argparse
+import shutil
+import subprocess
+import configparser
+
+import make
+
+DIR_PATH = os.path.dirname(__file__)
+BUILD_PATH = os.path.join(DIR_PATH, 'build')
+DIST_PATH = os.path.join(DIR_PATH, 'dist')
+SDK_SETTINGS_PATH = os.path.join(DIR_PATH, 'sdk_settings.ini')
+
+
+def build(app_name):
+    app_path = os.path.join(os.path.dirname(__file__), app_name)
+    req_path = os.path.join(app_path, 'requirements.txt')
+    try:
+        shutil.rmtree(BUILD_PATH)
+    except OSError:
+        pass
+    shutil.copytree(app_path, BUILD_PATH)
+    sproc = subprocess.Popen(['pip', 'install', '-r', str(req_path), '-t', str(BUILD_PATH)])
+    sproc.wait()
+    if sproc.returncode:
+        raise RuntimeError("received returncode: " + sproc.returncode)
+    for dir_name, _, _ in os.walk(BUILD_PATH):
+        if 'dist-info' in dir_name:
+            shutil.rmtree(dir_name)
+
+
+def dist(app_name):
+    try:
+        shutil.rmtree(DIST_PATH)
+    except OSError:
+        pass
+    os.mkdir(DIST_PATH)
+    make.new_package(BUILD_PATH, DIST_PATH)
+
+
+def clean(app_name):
+    try:
+        shutil.rmtree(DIST_PATH)
+        shutil.rmtree(BUILD_PATH)
+        make.clean(app_name)
+    except OSError:
+        pass
+
+
+def redeploy(app_name):
+    clean(app_name)
+    build(app_name)
+    dist(app_name)
+    make.uninstall()
+    make.install(DIST_PATH)
+
+
+def write_app_name_config_file(app_name):
+    config = configparser.ConfigParser()
+    config.read(SDK_SETTINGS_PATH)
+    config['sdk']['app_name'] = app_name
+    with open(SDK_SETTINGS_PATH, 'w') as outfile:
+        config.write(outfile)
+
+
+ACTIONS = {
+    'build': build,
+    'dist': dist,
+    'clean': clean,
+    'install': make.install,
+    'uninstall': make.uninstall,
+    'redeploy': redeploy
+}
+
+
+def get_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", help="actions to execute", choices=ACTIONS.keys())
+    parser.add_argument("app_name", help="app to use")
+    return parser
+
+
+def main():
+    args = get_parser().parse_args()
+    write_app_name_config_file(args.app_name)
+    make.AppBuilder(False)
+    ACTIONS[args.action](args.app_name)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/bin/package_application.py
+++ b/tools/bin/package_application.py
@@ -52,17 +52,19 @@ def hash_dir(target, hash_func=hashlib.sha256):
     return hashed_files
 
 
-def pack_package(app_root, app_name):
+def pack_package(app_root, app_name, dist_path=None):
+    if not dist_path:
+        dist_path = os.getcwd()
     print('app_root: {}'.format(app_root))
     print('app_name: {}'.format(app_name))
-    print("pack TAR:%s.tar" % app_name)
-    tar_name = "{}.tar".format(app_name)
-    tar = tarfile.open(tar_name, 'w')
+    tar_name = os.path.join(dist_path, "{}.tar".format(app_name))
+    print("pack TAR:%s" % tar_name)
+    tar = tarfile.TarFile.open(tar_name, 'w', dereference=True)
     tar.add(app_root, arcname=os.path.basename(app_root))
     tar.close()
 
-    print("gzip archive:%s.tar.gz" % app_name)
-    gzip_name = "{}.tar.gz".format(app_name)
+    print("gzip archive:%s.gz" % tar_name)
+    gzip_name = "{}.gz".format(tar_name)
     with open(tar_name, 'rb') as f_in:
         with gzip.open(gzip_name, 'wb') as f_out:
             shutil.copyfileobj(f_in, f_out)
@@ -101,7 +103,7 @@ def clean_bytecode_files(app_root):
     pass
 
 
-def package_application(app_root, pkey):
+def package_application(app_root, pkey, dist_path=None):
     app_root = os.path.realpath(app_root)
     app_config_file = os.path.join(app_root, CONFIG_FILE)
     app_metadata_folder = os.path.join(app_root, META_DATA_FOLDER)
@@ -113,7 +115,7 @@ def package_application(app_root, pkey):
 
     for section in config.sections():
         app_name = section
-        assert os.path.basename(app_root) == app_name
+        #assert os.path.basename(app_root) == app_name
 
         clean_manifest_folder(app_metadata_folder)
 
@@ -158,7 +160,7 @@ def package_application(app_root, pkey):
 
         create_signature(app_metadata_folder, pkey)
 
-        pack_package(app_root, section)
+        pack_package(app_root, section, dist_path)
 
         print('Package {}.tar.gz created'.format(section))
 


### PR DESCRIPTION
This refactoring makes `make.py` much more flexible and also introduces a `build.py` to create a build and dist.  The dist directory will contain the tarball that can then be installed to the router.  This is much cleaner than dumping it in the main directory.  The build directory will contain the dependencies that are available via pip in the requirements.txt file in each app project folder.  This allows one to not have to easily build a project with all its dependencies while not having to check the pip install-able dependencies into version control.