### PR TITLE
Fixed simple web server example

### DIFF
--- a/simple_web_server/readme.txt
+++ b/simple_web_server/readme.txt
@@ -5,7 +5,7 @@ simple_web_server
 
 Application Version
 ===================
-2.0
+2.1
 
 
 NCOS Devices Supported
@@ -24,6 +24,10 @@ Demonstrate a very basic web server using the http
 library which is included in NCOS. Port 9001 will
 need to be opened in the device firewall for access.
 
+SECURITY > Zone Firewall > Zone Forwarding > Add > \
+Source = Primary LAN Zone,
+Destination = Router,
+Filter Policy = Default Allow All > Save
 
 Expected Output
 ===============

--- a/simple_web_server/simple_web_server.py
+++ b/simple_web_server/simple_web_server.py
@@ -29,7 +29,7 @@ cp = EventingCSClient('simple_web_server')
 
 WEB_MESSAGE = "Hello World from Cradlepoint router!"
 
-server_address = ('localhost', 9001)
+server_address = ("", 9001)
 
 cp.log("Starting Server: {}".format(server_address))
 cp.log("Web Message is: {}".format(WEB_MESSAGE))


### PR DESCRIPTION
The single quotes and localhost was causing exceptions and the example would not work. Added instructions for allowing local router access to the simple web sever.