### PR TITLE
Fixed IP so custom dashboard is reachable

### DIFF
--- a/simple_custom_dashboard/simple_custom_dashboard.py
+++ b/simple_custom_dashboard/simple_custom_dashboard.py
@@ -110,7 +110,7 @@ class WebServerRequestHandler(SimpleHTTPRequestHandler):
 
 
 cp = EventingCSClient('simple_custom_dashboard')
-server_address = ('localhost', 9001)
+server_address = ('', 9001)
 cp.log('Starting Server: {}'.format(server_address))
 httpd = HTTPServer(server_address, WebServerRequestHandler)
 try:


### PR DESCRIPTION
The 'localhost' IP makes it so the server only responds to requests going to 'localhost'.  This means the dashboard cannot be reached from the primary lan.  

This fix makes the custom dashboard reachable from the primary lan, or any lan that has the proper firewall rules. 