### PR TITLE
Improve packager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+venv/
+build/

--- a/make.py
+++ b/make.py
@@ -371,33 +371,25 @@ def init(ceate_new_uuid):
     config.read(settings_file)
 
     # Initialize the globals based on the sdk_settings.ini contents.
-    if sdk_key in config:
-        if app_key in config[sdk_key]:
-            g_app_name = config[sdk_key][app_key]
-        else:
-            success = False
-            print('ERROR 1: The {} key does not exist in {}'.format(app_key, settings_file))
+    if sdk_key not in config:
+        print('ERROR: The {} section does not exist in {}'.format(sdk_key, settings_file))
+        return False
 
-        if ip_key in config[sdk_key]:
-            g_dev_client_ip = config[sdk_key][ip_key]
-        else:
-            success = False
-            print('ERROR 2: The {} key does not exist in {}'.format(ip_key, settings_file))
+    section = config[sdk_key]
 
-        if username_key in config[sdk_key]:
-            g_dev_client_username = config[sdk_key][username_key]
-        else:
+    for key in [app_key, ip_key, username_key, password_key]:
+        if key not in section:
+            print('ERROR: The {} key does not exist in {}'.format(key, settings_file))
+            # Maintain previous behavior of warning about each missing key by saving a flag instead of short-circuiting.
             success = False
-            print('ERROR 3: The {} key does not exist in {}'.format(username_key, settings_file))
 
-        if password_key in config[sdk_key]:
-            g_dev_client_password = config[sdk_key][password_key]
-        else:
-            success = False
-            print('ERROR 4: The {} key does not exist in {}'.format(password_key, settings_file))
-    else:
-        success = False
-        print('ERROR 5: The {} section does not exist in {}'.format(sdk_key, settings_file))
+    if not success:
+        return False
+
+    g_app_name = section[app_key]
+    g_dev_client_ip = section[ip_key]
+    g_dev_client_username = section[username_key]
+    g_dev_client_password = section[password_key]
 
     # This will also create a UUID if needed.
     get_app_uuid(ceate_new_uuid)

--- a/make.py
+++ b/make.py
@@ -175,7 +175,7 @@ def package():
     package_dir = os.path.join('tools', 'bin')
     package_script_path = os.path.join('tools', 'bin', 'package_application.py')
     app_path = os.path.join(g_app_name)
-    scan_for_cr(app_path)
+    # scan_for_cr(app_path)
 
     try:
         subprocess.check_output('{} {} {}'.format(g_python_cmd, package_script_path, app_path), shell=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pyOpenSSL

--- a/tools/bin/package_application.py
+++ b/tools/bin/package_application.py
@@ -19,7 +19,7 @@ CONFIG_FILE = 'package.ini'
 SIGNATURE_FILE = 'SIGNATURE.DS'
 MANIFEST_FILE = 'MANIFEST.json'
 
-BYTE_CODE_FILES = re.compile('^.*\.(pyc|pyo|pyd)$')
+BYTE_CODE_FILES = re.compile(r'^.*\.(pyc|pyo|pyd)$')
 BYTE_CODE_FOLDERS = re.compile('^(__pycache__)$')
 
 
@@ -94,9 +94,9 @@ def clean_manifest_folder(app_metadata_folder):
 
 def clean_bytecode_files(app_root):
     for path, dirs, files in os.walk(app_root):
-        for file in filter(lambda x: BYTE_CODE_FILES.match(x), files):
+        for file in filter(BYTE_CODE_FILES.match, files):
             os.remove(os.path.join(path, file))
-        for d in filter(lambda x: BYTE_CODE_FOLDERS.match(x), dirs):
+        for d in filter(BYTE_CODE_FOLDERS.match, dirs):
             shutil.rmtree(os.path.join(path, d))
     pass
 

--- a/tools/bin/package_application.py
+++ b/tools/bin/package_application.py
@@ -59,7 +59,7 @@ def pack_package(app_root, app_name):
     print("pack TAR:%s" % tar_name)
     #TODO: Consider using 'w:gz' to skip the additional gzip step.
     with tarfile.open(tar_name, 'w') as tar:
-        tar.add(app_root, arcname=os.path.basename(app_root))
+        tar.add(app_root, arcname=app_name)
 
     gzip_name = "{}.tar.gz".format(app_name)
     print("gzip archive:%s" % gzip_name)
@@ -73,8 +73,8 @@ def pack_package(app_root, app_name):
 
 def create_signature(meta_data_folder, pkey):
     manifest_file = os.path.join(meta_data_folder, MANIFEST_FILE)
+    checksum = file_checksum(hashlib.sha256, manifest_file).encode('utf-8')
     with open(os.path.join(meta_data_folder, SIGNATURE_FILE), 'wb') as sf:
-        checksum = file_checksum(hashlib.sha256, manifest_file).encode('utf-8')
         if pkey:
             sf.write(crypto.sign(pkey, checksum, 'sha256'))
         else:
@@ -162,9 +162,9 @@ def package_application(app_root, pkey):
 
         create_signature(app_metadata_folder, pkey)
 
-        pack_package(app_root, section)
+        pack_package(app_root, app_name)
 
-        print('Package {}.tar.gz created'.format(section))
+        print('Package {}.tar.gz created'.format(app_name))
 
 
 def argument_list(args):


### PR DESCRIPTION
Behavior changes:
- Be more aggressive about ignoring files. It used to ignore files if either the file or its direct dir had a leading dot. Now it checks every ancestor, up to the app_root.
- Copy files to a temporary directory and then builds that.
- Remove the need to halt on carriage return (#45).
- Fix a regex which (I believe) would have caused user's `myfile.cupyd` to be deleted during build.
- Add a rudimentary requirements.txt for the packager's libraries.
- Add a rudimentary .gitignore.
- There may be some behavior changes for the prints for "Did not include ...".

Possible future improvements:
- Better way to handle temporary files. Currently, it dumps the files into the `build/` folder (the use of which was removed in a previous version), and never cleans up.
- I don't know what to do about copying the file metadata. Will it be okay if the py files get copied into the router with or without global r/w/x?
- The `normcase` call (to canonicize the path before splitting) MIGHT cause problems with dots (but it shouldn't).
- Clean up `shouldinclude2`, which was added for how the code used os.walk (instead of `glob.iglob('**/*', recursive=True)`).
- Allow explicit file list or ignore list to be passed in.
- I wasn't sure whether we could use `pathlib`.
