### PR TITLE
Add github actions to build apps and check for package consistency

### DIFF
--- a/.github/workflows/builds.sh
+++ b/.github/workflows/builds.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+declare -a commands=("python3 make.py build" "python3 make.py build all" "cp *.tar.gz built_apps" "python3 make.py clean" "python3 make.py clean all")
+for cmds in "${commands[@]}";
+do
+	echo $cmds
+	result=$($cmds 2>&1 > output.txt)
+	if [ -n "$result" ]
+	then
+		echo "Error with app: $result"
+		cat output.txt
+		exit 1
+	else
+		cat output.txt
+		
+	fi
+done

--- a/.github/workflows/check_for_readme.sh
+++ b/.github/workflows/check_for_readme.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#Every app should have a readme.
+shopt -s extglob
+for folder in ./!(built_apps|tools)/
+do
+	if [ ! -f $folder/readme.txt ]
+	then
+       		echo "The app "$folder" is missing a readme.txt. Please ensure it's named "readme.txt"."
+       		exit 1
+	fi
+done

--- a/.github/workflows/check_root_readme_entries.sh
+++ b/.github/workflows/check_root_readme_entries.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#Every app should have an entry in the root readme.txt.
+shopt -s extglob
+for folder in ./!(built_apps|tools)/
+do
+	if ! grep -q ${folder:2:-1} README.md
+	then
+		echo "An entry for the app "$folder" is missing from the root readme."
+       		exit 1
+	fi
+done

--- a/.github/workflows/csclient_compare.sh
+++ b/.github/workflows/csclient_compare.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#Every app should have the same version of csclient.py. This test verifies a new app or modified app does not have an out of date csclient.py.
+file2="hello_world/csclient.py"
+for folder in ./*/;
+do
+        if test -f $folder/csclient.py; then
+                file1=$folder/csclient.py
+                if !(cmp "$file1" "$file2"); then
+                        echo "The csclient.py file in "$folder" is not the correct version"
+                        exit 1
+                fi
+        fi
+done

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,45 @@
+name: Test make and package contents consistency
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  run-make:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check each app has a readme.txt
+        run: |
+          chmod +x ./.github/workflows/check_for_readme.sh
+          ./.github/workflows/check_for_readme.sh
+        shell: bash
+      - name: Check root readme entries
+        run: |
+           chmod +x ./.github/workflows/check_root_readme_entries.sh 
+           ./.github/workflows/check_root_readme_entries.sh 
+        shell: bash       
+      - name: Check if there is a new csclient.py
+        run: |
+          chmod +x ./.github/workflows/csclient_compare.sh
+          ./.github/workflows/csclient_compare.sh
+        shell: bash
+      - uses: actions/checkout@v2
+      - name: Run make build and clean
+        run: |
+          chmod +x ./.github/workflows/builds.sh
+          ./.github/workflows/builds.sh
+        shell: bash
+      - name: Commit newly built apps to github
+        if: github.event_name == 'push'
+        run: |
+          git config --global user.name 'Github actions auto build packages'
+          git config --global user.email 'Github_actions_auto_build_packages@users.noreply.github.com'
+          git add built_apps/*
+          git commit -m "Rebuilt apps"
+          git push


### PR DESCRIPTION
Adds github action to:

- Verify each app has a readme.
- Verify each app has an entry in the root readme.
- Verify each app can be built and cleaned.
- Verify each app uses the same version of csclient.py.
- Build each app and add it to the built_apps dir on push to master. 