### PR TITLE
fixed the issue of not being able to gather data points with speedtest disabled

### DIFF
--- a/Mobile_Site_Survey/Mobile_Site_Survey - compact CSV.py
+++ b/Mobile_Site_Survey/Mobile_Site_Survey - compact CSV.py
@@ -414,6 +414,7 @@ def run_tests(sim):
             except:
                 cp.log(f'Ookla failed to start for source {source_ip} on {sim}.  Trying again...')
                 time.sleep(1)
+                retries += 1
                 pass
         else:
             log_all(f'Ookla startup exceeded retries for source {source_ip} on {sim}')

--- a/Mobile_Site_Survey/Mobile_Site_Survey.py
+++ b/Mobile_Site_Survey/Mobile_Site_Survey.py
@@ -427,6 +427,7 @@ def run_tests(sim):
         except:
             cp.log(f'Ookla failed to start for source {source_ip} on {sim}.  Trying again...')
             time.sleep(1)
+            retries += 1
             pass
     else:
         log_all(f'Ookla startup exceeded retries for source {source_ip} on {sim}', logs)


### PR DESCRIPTION
I noticed that the part of the code responsible for bringing up the ookla speedtest server enters into an infinite loop as the "retries" variable was not being incremented in the except block. This commit makes that change.