### PR TITLE
Enable use of alternate Tailscale auth server

### DIFF
--- a/tailscale/README.md
+++ b/tailscale/README.md
@@ -35,6 +35,7 @@ For example:
 | ---- | ----- | ----- |
 | tsroutes | 172.16.0.0/12 | Manually add a tailscale routes, comma separated
 | tsversion | 1.60.1 | Use this version of tailscale explicitly
+| tsserver | https://headscale.example.com | Enable use of self-hosted login server such as [Headscale](https://headscale.net/)
 
 ## Overlapping subnets
 You can use tailscales 4via6 feature if you would like to get to devices behind a Cradlepoint routers that might share the same subnet.  First come up with a site id you would like to use (0-65535). Then from a computer with tailscale installed execute: `tailscale debug via [site-id] [subnet]`. For example: `tailscale debug via 1 172.16.0.0/12` should generate a 4via6 subnet of `fd7a:115c:a1e0:b1a:0:1:ac10:0/108`. Add this as a tsroute above and you can access the network via ipv6 or by the domain name following the format `Q-R-S-T-via-X` where Q-R-S-T is the ipv4 address and X is the site id, e.g.: `172-16-0-1-via-1`.

--- a/tailscale/get_tskey.py
+++ b/tailscale/get_tskey.py
@@ -6,7 +6,7 @@ import sys
 if __name__ == "__main__":
     command = sys.argv[1]
 
-    if command in ["tskey", "tsversion"]:
+    if command in ["tskey", "tsversion", "tsserver"]:
         try:
             value = get_appdata(command)
             if value:

--- a/tailscale/package.ini
+++ b/tailscale/package.ini
@@ -1,5 +1,5 @@
 [tailscale]
-uuid = d4c47aa5-4409-4edf-bf1a-550182ad70a1
+uuid = 9faa8914-d556-4c82-aec6-d536767d836f
 vendor = Cradlepoint
 notes = tailscale
 version_major = 0


### PR DESCRIPTION
Hello, I have created a patch to allow use of Tailscale and a custom authentication server (such as Headscale). The readme has been updated to explain how to use a custom auth server and "normal" use should not be impacted (i.e. not entering anything in SDK Data for 'tsserver'). 

I would like to update the Tailscale readme further to detail ensuring that the subnet is accessible via the Tailnet but I'm struggling with this aspect. I created [this](https://github.com/cradlepoint/sdk-samples/issues/124) issue regarding this. I would appreciate some help on this item so I can clarify the readme in the PR.

-Ben