### PR TITLE
set FTP root to /var/media instead of ./

### DIFF
--- a/ftp_server/ftp_server.py
+++ b/ftp_server/ftp_server.py
@@ -16,8 +16,7 @@ from pyftpdlib.servers import FTPServer
 # This requires a USB compatible storage device plugged into
 # the router. It will mount to /var/media.
 if sys.platform == 'linux2':
-    # FTP_DIR = '/var/media'
-    FTP_DIR = './'
+    FTP_DIR = '/var/media'
 else:
     FTP_DIR = os.getcwd()
 


### PR DESCRIPTION
In current state, FTP server is always loading ./ as the root directory regardless of /var/media.